### PR TITLE
✨ feat: add scripts and docs to transfer PRs and tag Hacktoberfest

### DIFF
--- a/ADD_HACKTOBERFEST_LABELS.md
+++ b/ADD_HACKTOBERFEST_LABELS.md
@@ -1,0 +1,66 @@
+# Add Hacktoberfest Labels to PRs
+
+## For Repository Maintainer (Resaqulyubi)
+
+### Quick Method - Using GitHub CLI
+
+```bash
+# 1. Create the hacktoberfest label (if it doesn't exist)
+gh label create hacktoberfest \
+  --repo Resaqulyubi/vue-wedding-sample-animation \
+  --description "Hacktoberfest participation" \
+  --color "FF6B6B"
+
+# 2. Add the label to all 6 PRs
+gh pr edit 1 --repo Resaqulyubi/vue-wedding-sample-animation --add-label "hacktoberfest"
+gh pr edit 2 --repo Resaqulyubi/vue-wedding-sample-animation --add-label "hacktoberfest"
+gh pr edit 3 --repo Resaqulyubi/vue-wedding-sample-animation --add-label "hacktoberfest"
+gh pr edit 4 --repo Resaqulyubi/vue-wedding-sample-animation --add-label "hacktoberfest"
+gh pr edit 5 --repo Resaqulyubi/vue-wedding-sample-animation --add-label "hacktoberfest"
+gh pr edit 6 --repo Resaqulyubi/vue-wedding-sample-animation --add-label "hacktoberfest"
+```
+
+### Alternative - Using GitHub Web Interface
+
+1. Go to https://github.com/Resaqulyubi/vue-wedding-sample-animation/labels
+2. Click "New label"
+3. Name: `hacktoberfest`
+4. Description: `Hacktoberfest participation`
+5. Color: `#FF6B6B` (or any color you prefer)
+6. Click "Create label"
+
+Then for each PR (1-6):
+1. Go to the PR page
+2. Click on "Labels" in the right sidebar
+3. Select "hacktoberfest"
+
+### Automated Script
+
+```bash
+#!/bin/bash
+
+REPO="Resaqulyubi/vue-wedding-sample-animation"
+
+# Create label
+gh label create hacktoberfest \
+  --repo "$REPO" \
+  --description "Hacktoberfest participation" \
+  --color "FF6B6B" 2>/dev/null || echo "Label may already exist"
+
+# Add to all PRs
+for pr in {1..6}; do
+  echo "Adding hacktoberfest label to PR #$pr..."
+  gh pr edit $pr --repo "$REPO" --add-label "hacktoberfest"
+done
+
+echo "✓ Done! All PRs now have the hacktoberfest label"
+```
+
+## PR Links
+
+- PR #1: https://github.com/Resaqulyubi/vue-wedding-sample-animation/pull/1
+- PR #2: https://github.com/Resaqulyubi/vue-wedding-sample-animation/pull/2
+- PR #3: https://github.com/Resaqulyubi/vue-wedding-sample-animation/pull/3
+- PR #4: https://github.com/Resaqulyubi/vue-wedding-sample-animation/pull/4
+- PR #5: https://github.com/Resaqulyubi/vue-wedding-sample-animation/pull/5
+- PR #6: https://github.com/Resaqulyubi/vue-wedding-sample-animation/pull/6

--- a/PR_TRANSFER_GUIDE.md
+++ b/PR_TRANSFER_GUIDE.md
@@ -1,0 +1,155 @@
+# Pull Request Transfer Guide
+
+## Overview
+This guide explains how to transfer all 6 pull requests from `uratmangun/vue-wedding-sample-animation` to `Resaqulyubi/vue-wedding-sample-animation`.
+
+## Prerequisites
+- You must have push access to `Resaqulyubi/vue-wedding-sample-animation`
+- GitHub CLI (`gh`) must be installed and authenticated
+
+## Pull Requests to Transfer
+
+1. **PR #6**: Add Javanese README for wedding animation project (branch: `jv-readme-wedding-anim`)
+2. **PR #5**: Add Indonesian README for wedding animation app (branch: `add-readme-indonesia-wedding-app`)
+3. **PR #4**: Add Arabic README for wedding invitation project (branch: `arabic-readme-wedding-invite`)
+4. **PR #3**: Add README in Aramaic for wedding animation sample (branch: `aramaic-readme-wedding-sample`)
+5. **PR #2**: Replace README with Vue wedding invitation overview (branch: `docs/vue-wedding-readme`)
+6. **PR #1**: Add new Landing.vue page for wedding site (branch: `u-branch-1`)
+
+## Method 1: Automated Script (For Repository Owner)
+
+If you have access to `Resaqulyubi/vue-wedding-sample-animation`, run the included `transfer-prs.sh` script:
+
+```bash
+chmod +x transfer-prs.sh
+./transfer-prs.sh
+```
+
+## Method 2: Manual Transfer Steps
+
+### Step 1: Clone both repositories
+
+```bash
+# Clone source repository
+git clone git@github.com:uratmangun/vue-wedding-sample-animation.git source-repo
+cd source-repo
+
+# Add target repository as remote
+git remote add target git@github.com:Resaqulyubi/vue-wedding-sample-animation.git
+```
+
+### Step 2: Transfer each branch and create PR
+
+For each PR, repeat these steps:
+
+#### PR #6: Javanese README
+```bash
+git fetch origin jv-readme-wedding-anim
+git checkout jv-readme-wedding-anim
+git push target jv-readme-wedding-anim:jv-readme-wedding-anim
+
+gh pr create \
+  --repo Resaqulyubi/vue-wedding-sample-animation \
+  --base master \
+  --head jv-readme-wedding-anim \
+  --title "Add Javanese README for wedding animation project" \
+  --body "Add a new README_JV.md written in Javanese to document the wedding animation web app. The file describes features, tech stack, project structure, setup and deployment instructions (Docker and Nixpacks), customization notes, and license. This provides localized documentation for Javanese-speaking contributors and users."
+```
+
+#### PR #5: Indonesian README
+```bash
+git fetch origin add-readme-indonesia-wedding-app
+git checkout add-readme-indonesia-wedding-app
+git push target add-readme-indonesia-wedding-app:add-readme-indonesia-wedding-app
+
+gh pr create \
+  --repo Resaqulyubi/vue-wedding-sample-animation \
+  --base master \
+  --head add-readme-indonesia-wedding-app \
+  --title "Add Indonesian README for wedding animation app" \
+  --body "Provide an Indonesian-language README describing the wedding invitation animation web app. The new README (README_ID.md) documents features, technologies, project structure, setup and deployment instructions (Docker and Nixpacks), customization notes, and license information so Indonesian-speaking contributors can quickly understand and run the project."
+```
+
+#### PR #4: Arabic README
+```bash
+git fetch origin arabic-readme-wedding-invite
+git checkout arabic-readme-wedding-invite
+git push target arabic-readme-wedding-invite:arabic-readme-wedding-invite
+
+gh pr create \
+  --repo Resaqulyubi/vue-wedding-sample-animation \
+  --base master \
+  --head arabic-readme-wedding-invite \
+  --title "Add Arabic README for wedding invitation project" \
+  --body "Create an Arabic-language README (README_AR.md) describing the wedding invitation demo built with Laravel, Vue.js and GSAP. The file documents features, tech stack, project structure, setup and deployment instructions (Docker/Nixpacks), customization notes, and licensing — providing Arabic-speaking contributors and users with clear guidance on running and deploying the project."
+```
+
+#### PR #3: Aramaic README
+```bash
+git fetch origin aramaic-readme-wedding-sample
+git checkout aramaic-readme-wedding-sample
+git push target aramaic-readme-wedding-sample:aramaic-readme-wedding-sample
+
+gh pr create \
+  --repo Resaqulyubi/vue-wedding-sample-animation \
+  --base master \
+  --head aramaic-readme-wedding-sample \
+  --title "Add README in Aramaic for wedding animation sample" \
+  --body "Add a new README-ARAMAIC.md documenting the wedding invitation animation sample in Aramaic. The file introduces the project, lists features, tech stack (Vue 3, GSAP, Laravel 10, PHP 8.1+, Vite, Tailwind), project structure, setup and build steps, deployment notes (Docker/Nixpacks), optimization tips, and contributor guidance. This README was added to provide native-language documentation and onboarding information for Aramaic-speaking contributors and users."
+```
+
+#### PR #2: Vue Wedding README
+```bash
+git fetch origin docs/vue-wedding-readme
+git checkout docs/vue-wedding-readme
+git push target docs/vue-wedding-readme:docs/vue-wedding-readme
+
+gh pr create \
+  --repo Resaqulyubi/vue-wedding-sample-animation \
+  --base master \
+  --head docs/vue-wedding-readme \
+  --title "Replace README with Vue wedding invitation overview" \
+  --body "Replace the old Laravel boilerplate README with a concise, project-specific README describing the Vue-based wedding invitation landing page, its features, tech stack, deployment options (Docker and Nixpacks), and setup instructions. This update was needed to provide clear documentation tailored to this project's structure and workflows, removing irrelevant Laravel template content and adding practical setup, build, and deployment guidance for contributors and deployers."
+```
+
+#### PR #1: Landing Page
+```bash
+git fetch origin u-branch-1
+git checkout u-branch-1
+git push target u-branch-1:u-branch-1
+
+gh pr create \
+  --repo Resaqulyubi/vue-wedding-sample-animation \
+  --base master \
+  --head u-branch-1 \
+  --title "Add new Landing.vue page for wedding site" \
+  --body "- No changes detected (no commit messages provided)"
+```
+
+## Method 3: Request Collaborator Access
+
+If you need to run the transfer yourself:
+
+1. Ask the owner of `Resaqulyubi/vue-wedding-sample-animation` to add you as a collaborator with push access
+2. Once granted, run the `transfer-prs.sh` script from this repository
+
+## Troubleshooting
+
+### Permission Denied Error
+- Ensure you have push access to the target repository
+- Check that your SSH key is properly configured: `ssh -T git@github.com`
+- Verify you're authenticated with the correct GitHub account
+
+### Branch Already Exists
+- If branches already exist in target repo, use force push: `git push target branch-name:branch-name -f`
+
+### PR Already Exists
+- If a PR already exists for a branch, the script will skip it with a warning
+
+## Verification
+
+After transfer, verify all PRs are created:
+
+```bash
+gh pr list --repo Resaqulyubi/vue-wedding-sample-animation --state all
+```

--- a/create-upstream-prs.sh
+++ b/create-upstream-prs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Create Pull Requests from fork (uratmangun) to upstream (Resaqulyubi)
+
+FORK_OWNER="uratmangun"
+UPSTREAM_REPO="Resaqulyubi/vue-wedding-sample-animation"
+
+echo "=== Creating Pull Requests from Fork to Upstream ==="
+echo "Fork: ${FORK_OWNER}/vue-wedding-sample-animation"
+echo "Upstream: ${UPSTREAM_REPO}"
+echo ""
+
+# Array of PR data (branch, base, title, body)
+declare -a PRS=(
+    "jv-readme-wedding-anim|master|Add Javanese README for wedding animation project|Add a new README_JV.md written in Javanese to document the wedding animation web app. The file describes features, tech stack, project structure, setup and deployment instructions (Docker and Nixpacks), customization notes, and license. This provides localized documentation for Javanese-speaking contributors and users."
+    "add-readme-indonesia-wedding-app|master|Add Indonesian README for wedding animation app|Provide an Indonesian-language README describing the wedding invitation animation web app. The new README (README_ID.md) documents features, technologies, project structure, setup and deployment instructions (Docker and Nixpacks), customization notes, and license information so Indonesian-speaking contributors can quickly understand and run the project."
+    "arabic-readme-wedding-invite|master|Add Arabic README for wedding invitation project|Create an Arabic-language README (README_AR.md) describing the wedding invitation demo built with Laravel, Vue.js and GSAP. The file documents features, tech stack, project structure, setup and deployment instructions (Docker/Nixpacks), customization notes, and licensing — providing Arabic-speaking contributors and users with clear guidance on running and deploying the project."
+    "aramaic-readme-wedding-sample|master|Add README in Aramaic for wedding animation sample|Add a new README-ARAMAIC.md documenting the wedding invitation animation sample in Aramaic. The file introduces the project, lists features, tech stack (Vue 3, GSAP, Laravel 10, PHP 8.1+, Vite, Tailwind), project structure, setup and build steps, deployment notes (Docker/Nixpacks), optimization tips, and contributor guidance. This README was added to provide native-language documentation and onboarding information for Aramaic-speaking contributors and users."
+    "docs/vue-wedding-readme|master|Replace README with Vue wedding invitation overview|Replace the old Laravel boilerplate README with a concise, project-specific README describing the Vue-based wedding invitation landing page, its features, tech stack, deployment options (Docker and Nixpacks), and setup instructions. This update was needed to provide clear documentation tailored to this project's structure and workflows, removing irrelevant Laravel template content and adding practical setup, build, and deployment guidance for contributors and deployers."
+    "u-branch-1|master|Add new Landing.vue page for wedding site|- No changes detected (no commit messages provided)"
+)
+
+# Process each PR
+for pr_data in "${PRS[@]}"; do
+    IFS='|' read -r branch base title body <<< "$pr_data"
+    
+    echo ""
+    echo "=== Creating PR for branch: $branch ==="
+    echo "Title: $title"
+    
+    # Create PR from fork to upstream
+    # The head format is "fork-owner:branch" when creating cross-repository PRs
+    gh pr create \
+        --repo "$UPSTREAM_REPO" \
+        --base "$base" \
+        --head "${FORK_OWNER}:${branch}" \
+        --title "$title" \
+        --body "$body" && echo "✓ Successfully created PR for $branch" || echo "⚠ Failed to create PR for $branch (may already exist)"
+done
+
+echo ""
+echo "=== PR Creation Complete ==="
+echo "Check the pull requests at: https://github.com/${UPSTREAM_REPO}/pulls"

--- a/transfer-prs.sh
+++ b/transfer-prs.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Transfer Pull Requests from uratmangun/vue-wedding-sample-animation to Resaqulyubi/vue-wedding-sample-animation
+
+SOURCE_REPO="uratmangun/vue-wedding-sample-animation"
+TARGET_REPO="Resaqulyubi/vue-wedding-sample-animation"
+
+echo "=== Transferring Pull Requests ==="
+echo "Source: $SOURCE_REPO"
+echo "Target: $TARGET_REPO"
+echo ""
+
+# Add target repository as a remote if not already added
+if ! git remote | grep -q "target-repo"; then
+    echo "Adding target repository as remote..."
+    git remote add target-repo "git@github.com:${TARGET_REPO}.git"
+fi
+
+# Fetch all branches from source
+echo "Fetching all branches from source..."
+git fetch origin
+
+# Array of PR data (number, branch, base, title, body)
+declare -a PRS=(
+    "6|jv-readme-wedding-anim|master|Add Javanese README for wedding animation project|Add a new README_JV.md written in Javanese to document the wedding animation web app. The file describes features, tech stack, project structure, setup and deployment instructions (Docker and Nixpacks), customization notes, and license. This provides localized documentation for Javanese-speaking contributors and users."
+    "5|add-readme-indonesia-wedding-app|master|Add Indonesian README for wedding animation app|Provide an Indonesian-language README describing the wedding invitation animation web app. The new README (README_ID.md) documents features, technologies, project structure, setup and deployment instructions (Docker and Nixpacks), customization notes, and license information so Indonesian-speaking contributors can quickly understand and run the project."
+    "4|arabic-readme-wedding-invite|master|Add Arabic README for wedding invitation project|Create an Arabic-language README (README_AR.md) describing the wedding invitation demo built with Laravel, Vue.js and GSAP. The file documents features, tech stack, project structure, setup and deployment instructions (Docker/Nixpacks), customization notes, and licensing — providing Arabic-speaking contributors and users with clear guidance on running and deploying the project."
+    "3|aramaic-readme-wedding-sample|master|Add README in Aramaic for wedding animation sample|Add a new README-ARAMAIC.md documenting the wedding invitation animation sample in Aramaic. The file introduces the project, lists features, tech stack (Vue 3, GSAP, Laravel 10, PHP 8.1+, Vite, Tailwind), project structure, setup and build steps, deployment notes (Docker/Nixpacks), optimization tips, and contributor guidance. This README was added to provide native-language documentation and onboarding information for Aramaic-speaking contributors and users."
+    "2|docs/vue-wedding-readme|master|Replace README with Vue wedding invitation overview|Replace the old Laravel boilerplate README with a concise, project-specific README describing the Vue-based wedding invitation landing page, its features, tech stack, deployment options (Docker and Nixpacks), and setup instructions. This update was needed to provide clear documentation tailored to this project's structure and workflows, removing irrelevant Laravel template content and adding practical setup, build, and deployment guidance for contributors and deployers."
+    "1|u-branch-1|master|Add new Landing.vue page for wedding site|- No changes detected (no commit messages provided)"
+)
+
+# Process each PR
+for pr_data in "${PRS[@]}"; do
+    IFS='|' read -r pr_num branch base title body <<< "$pr_data"
+    
+    echo ""
+    echo "=== Processing PR #$pr_num: $title ==="
+    
+    # Check if branch exists locally
+    if git show-ref --verify --quiet "refs/heads/$branch"; then
+        echo "Branch $branch exists locally"
+    elif git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+        echo "Checking out branch $branch from origin..."
+        git checkout -b "$branch" "origin/$branch"
+    else
+        echo "ERROR: Branch $branch not found"
+        continue
+    fi
+    
+    # Push branch to target repository
+    echo "Pushing branch $branch to target repository..."
+    git push target-repo "$branch:$branch" -f
+    
+    # Create PR in target repository
+    echo "Creating PR in target repository..."
+    
+    # Escape quotes in title and body for gh cli
+    escaped_title=$(echo "$title" | sed 's/"/\\"/g')
+    escaped_body=$(echo "$body" | sed 's/"/\\"/g')
+    
+    gh pr create \
+        --repo "$TARGET_REPO" \
+        --base "$base" \
+        --head "$branch" \
+        --title "$escaped_title" \
+        --body "$escaped_body" || echo "Failed to create PR (may already exist)"
+    
+    echo "✓ Completed PR #$pr_num"
+done
+
+echo ""
+echo "=== Transfer Complete ==="
+echo "All pull requests have been transferred to $TARGET_REPO"


### PR DESCRIPTION
Add transfer-prs.sh to automate transferring and recreating six pull
requests from uratmangun/vue-wedding-sample-animation to
Resaqulyubi/vue-wedding-sample-animation. The script prepares remotes,
fetches branches, and defines PR metadata (branch, base, title, body)
to recreate each PR on the target repo, simplifying migration and
preserving localized README contributions.

Add ADD_HACKTOBERFEST_LABELS.md documenting three ways to add a
hacktoberfest label to the target repository and its PRs: GitHub CLI
commands, web UI steps, and an automated shell script. Provide PR links
and an example gh-based automation to quickly mark all six PRs for
Hacktoberfest participation.

These changes streamline repo maintainership tasks, speed up PR
migration, and ensure contributors are credited for Hacktoberfest.